### PR TITLE
feat: add signal grading system to backtester

### DIFF
--- a/src/backtester/grading.py
+++ b/src/backtester/grading.py
@@ -1,0 +1,42 @@
+"""Signal grading: classifies signals by confluence level."""
+
+from __future__ import annotations
+
+from enum import Enum
+
+from trading_signal_bot.models import Scenario
+
+
+class SignalGrade(str, Enum):
+    A_PLUS = "A+"
+    A = "A"
+    B = "B"
+
+
+_SCENARIO_GRADE: dict[Scenario, SignalGrade] = {
+    Scenario.BUY_CHAIN: SignalGrade.A_PLUS,
+    Scenario.SELL_CHAIN: SignalGrade.A_PLUS,
+    Scenario.BUY_CHAIN_HP: SignalGrade.A_PLUS,
+    Scenario.SELL_CHAIN_HP: SignalGrade.A_PLUS,
+    Scenario.BUY_S1: SignalGrade.A,
+    Scenario.SELL_S1: SignalGrade.A,
+    Scenario.BUY_S2: SignalGrade.A,
+    Scenario.SELL_S2: SignalGrade.A,
+    Scenario.BUY_M1: SignalGrade.B,
+    Scenario.SELL_M1: SignalGrade.B,
+}
+
+
+def compute_grade(scenario: Scenario | str) -> SignalGrade:
+    """Compute signal grade from scenario.
+
+    A+ = full confluence (M15 LWMA + M15 stoch cross + M1 stoch cross + M1 LWMA cross)
+    A  = M15 gate + M1 partial confirm (stoch or LWMA, not both)
+    B  = M1 only, no M15 context
+    """
+    if isinstance(scenario, str):
+        try:
+            scenario = Scenario(scenario)
+        except ValueError:
+            return SignalGrade.B
+    return _SCENARIO_GRADE.get(scenario, SignalGrade.B)

--- a/src/backtester/report.py
+++ b/src/backtester/report.py
@@ -41,6 +41,7 @@ class BacktestReport:
     max_consecutive_losses: int = 0
     by_scenario: dict[str, ScenarioStats] = field(default_factory=dict)
     by_direction: dict[str, ScenarioStats] = field(default_factory=dict)
+    by_grade: dict[str, ScenarioStats] = field(default_factory=dict)
     exit_reason_counts: dict[str, int] = field(default_factory=dict)
 
 
@@ -86,6 +87,9 @@ def build_report(trades: list[RecordedTrade]) -> BacktestReport:
     # By direction
     by_direction = _group_stats(trades, key_fn=lambda t: t.direction.value)
 
+    # By grade
+    by_grade = _group_stats(trades, key_fn=lambda t: t.grade)
+
     # Exit reason counts
     exit_reason_counts: dict[str, int] = defaultdict(int)
     for t in trades:
@@ -108,6 +112,7 @@ def build_report(trades: list[RecordedTrade]) -> BacktestReport:
         max_consecutive_losses=max_consecutive_losses,
         by_scenario=dict(by_scenario),
         by_direction=dict(by_direction),
+        by_grade=dict(by_grade),
         exit_reason_counts=dict(exit_reason_counts),
     )
 
@@ -146,6 +151,12 @@ def format_report(report: BacktestReport, config: object | None = None) -> str:
         lines.append(
             f"  {direction}: {stats.total} trades, {wr:.1f}% win, PnL={stats.total_pnl:.5f}"
         )
+
+    lines.append("")
+    lines.append("--- By Grade ---")
+    for grade, stats in sorted(report.by_grade.items()):
+        wr = (stats.wins / stats.total) * 100.0 if stats.total > 0 else 0.0
+        lines.append(f"  {grade}: {stats.total} trades, {wr:.1f}% win, PnL={stats.total_pnl:.5f}")
 
     lines.append("")
     lines.append("--- Exit Reasons ---")
@@ -189,6 +200,7 @@ def export_trade_log(trades: list[RecordedTrade], path: Path) -> None:
                 "sl_price",
                 "tp1_price",
                 "tp2_price",
+                "grade",
             ]
         )
         for trade in trades:
@@ -207,6 +219,7 @@ def export_trade_log(trades: list[RecordedTrade], path: Path) -> None:
                     f"{trade.sl_price:.5f}" if trade.sl_price is not None else "",
                     f"{trade.tp1_price:.5f}" if trade.tp1_price is not None else "",
                     f"{trade.tp2_price:.5f}" if trade.tp2_price is not None else "",
+                    trade.grade,
                 ]
             )
 

--- a/src/backtester/trade_recorder.py
+++ b/src/backtester/trade_recorder.py
@@ -6,6 +6,8 @@ from enum import Enum
 
 from trading_signal_bot.models import Direction, Signal
 
+from .grading import compute_grade
+
 
 class ExitReason(str, Enum):
     """Why a trade was closed."""
@@ -33,6 +35,7 @@ class RecordedTrade:
     sl_price: float | None = None
     tp1_price: float | None = None
     tp2_price: float | None = None
+    grade: str = ""
 
 
 def _entry_time(signal: Signal) -> datetime:
@@ -66,6 +69,7 @@ def make_trade(
         sl_price=sl_price,
         tp1_price=tp1_price,
         tp2_price=tp2_price,
+        grade=compute_grade(signal.scenario).value,
     )
 
 
@@ -89,4 +93,5 @@ def time_based_outcome(
         exit_time_utc=future_time_utc,
         pnl=pnl,
         exit_reason=ExitReason.TIME,
+        grade=compute_grade(signal.scenario).value,
     )

--- a/tests/unit/test_grading.py
+++ b/tests/unit/test_grading.py
@@ -1,0 +1,38 @@
+"""Tests for signal grading."""
+
+from __future__ import annotations
+
+from backtester.grading import SignalGrade, compute_grade
+from trading_signal_bot.models import Scenario
+
+
+class TestComputeGrade:
+    def test_chain_scenarios_grade_a_plus(self) -> None:
+        assert compute_grade(Scenario.BUY_CHAIN) is SignalGrade.A_PLUS
+        assert compute_grade(Scenario.SELL_CHAIN) is SignalGrade.A_PLUS
+        assert compute_grade(Scenario.BUY_CHAIN_HP) is SignalGrade.A_PLUS
+        assert compute_grade(Scenario.SELL_CHAIN_HP) is SignalGrade.A_PLUS
+
+    def test_s1_scenarios_grade_a(self) -> None:
+        assert compute_grade(Scenario.BUY_S1) is SignalGrade.A
+        assert compute_grade(Scenario.SELL_S1) is SignalGrade.A
+
+    def test_s2_scenarios_grade_a(self) -> None:
+        assert compute_grade(Scenario.BUY_S2) is SignalGrade.A
+        assert compute_grade(Scenario.SELL_S2) is SignalGrade.A
+
+    def test_m1_scenarios_grade_b(self) -> None:
+        assert compute_grade(Scenario.BUY_M1) is SignalGrade.B
+        assert compute_grade(Scenario.SELL_M1) is SignalGrade.B
+
+    def test_summary_scenarios_default_b(self) -> None:
+        assert compute_grade(Scenario.BUY_SUMMARY) is SignalGrade.B
+        assert compute_grade(Scenario.SELL_SUMMARY) is SignalGrade.B
+
+    def test_string_scenario_lookup(self) -> None:
+        assert compute_grade("BUY_CHAIN") is SignalGrade.A_PLUS
+        assert compute_grade("BUY_S1") is SignalGrade.A
+        assert compute_grade("BUY_M1") is SignalGrade.B
+
+    def test_unknown_string_defaults_b(self) -> None:
+        assert compute_grade("UNKNOWN_SCENARIO") is SignalGrade.B

--- a/tests/unit/test_report_v2.py
+++ b/tests/unit/test_report_v2.py
@@ -27,6 +27,7 @@ def _trade(
     sl: float | None = None,
     tp1: float | None = None,
     tp2: float | None = None,
+    grade: str = "A",
 ) -> RecordedTrade:
     """Helper to build a RecordedTrade with minimal fields."""
     entry = 100.0
@@ -45,6 +46,7 @@ def _trade(
         sl_price=sl,
         tp1_price=tp1,
         tp2_price=tp2,
+        grade=grade,
     )
 
 
@@ -218,6 +220,41 @@ class TestFormatReport:
         assert "Backtest Report" in text
         assert "Win Rate" in text
         assert "Profit Factor" in text
+        assert "By Grade" in text
+
+
+class TestByGradeGrouping:
+    """By-grade grouping correctness."""
+
+    def test_by_grade(self) -> None:
+        trades = [
+            _trade(pnl=5.0, grade="A+"),
+            _trade(pnl=-2.0, grade="A+"),
+            _trade(pnl=3.0, grade="A"),
+            _trade(pnl=1.0, grade="B"),
+            _trade(pnl=-1.0, grade="B"),
+        ]
+        report = build_report(trades)
+        assert "A+" in report.by_grade
+        assert "A" in report.by_grade
+        assert "B" in report.by_grade
+        assert report.by_grade["A+"].total == 2
+        assert report.by_grade["A+"].wins == 1
+        assert report.by_grade["A"].total == 1
+        assert report.by_grade["A"].wins == 1
+        assert report.by_grade["B"].total == 2
+        assert report.by_grade["B"].wins == 1
+
+    def test_format_report_includes_grade(self) -> None:
+        trades = [
+            _trade(pnl=5.0, grade="A+"),
+            _trade(pnl=3.0, grade="B"),
+        ]
+        report = build_report(trades)
+        text = format_report(report)
+        assert "--- By Grade ---" in text
+        assert "A+" in text
+        assert "B" in text
 
 
 class TestCsvExport:
@@ -246,4 +283,5 @@ class TestCsvExport:
         lines = csv_path.read_text().strip().split("\n")
         assert "signal_id" in lines[0]
         assert "exit_reason" in lines[0]
+        assert "grade" in lines[0]
         assert len(lines) == 3  # header + 2 trades


### PR DESCRIPTION
Classify signals by confluence level (A+/A/B) based on scenario to analyze which setups are most profitable.

## Changes
- New `src/backtester/grading.py` — `SignalGrade` enum + `compute_grade()` mapping
- Add `grade` field to `RecordedTrade`, populated in both factory functions
- Add `by_grade` grouping to `BacktestReport` and `format_report()`
- Add `grade` column to CSV trade log export
- 7 new tests in `test_grading.py`, 3 new tests in `test_report_v2.py`

## Grade mapping
- A+: CHAIN/CHAIN_HP (full M15+M1 confluence)
- A: S1/S2 (M15 gate + partial M1 confirm)
- B: M1 only (no M15 context)

## Test plan
- [x] 125 tests passing
- [x] black/ruff clean
- [ ] EC2 smoke test with `--mode all`